### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-    @items = Item.all
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,7 @@ class Item < ApplicationRecord
     validates :discription
     validates :price, format: { with: /\A[0-9]+\z/ }
     validates :price, numericality: { greater_than: 299, less_than: 9_999_999 }
-    
+
     with_options numericality: { other_than: 1 } do
       validates :category_id
       validates :condition_id
@@ -23,6 +23,5 @@ class Item < ApplicationRecord
       validates :area_id
       validates :ship_days_id
     end
-
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,24 +127,22 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item|%>
       <li class='list'>
-        <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%#div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div><% @items.each do |item|%>
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,28 +152,6 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,8 +126,8 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-    <% @items.each do |item|%>
+    <% if @items.present? %>
+     <% @items.each do |item|%>
       <li class='list'>
         <div class='item-img-content'>
            <%= image_tag item.image, class: "item-img" if item.image.attached? %>
@@ -149,11 +149,29 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
+    <% else %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+      </li>
+    <% end %>
     </ul>
   </div>
+ <% end %>
   <%# /商品一覧 %>
 </div>
 <div class='purchase-btn'>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -60,12 +60,12 @@ describe Item do
       it 'priceが全角数字だと登録できない' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'priceに文字列が含まれていると登録できない' do
         @item.price = 'a1000'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'priceが299円以下だと登録できない' do
         @item.price = '299'


### PR DESCRIPTION
#What
商品一覧表示機能の実装
#Why
商品をユーザー（ログインの有無に関わらず）に見てもらうため
（sold outの記述は購入後に搭載のため現状は非搭載）

以下にGyazoのリンクを添付しておりますのでご確認ください。
https://gyazo.com/fa64b00bb1cbf0ef3cf29bc56bc33132